### PR TITLE
instances add fails due to volumes.size being sent as null instead of integer for 'root' volume

### DIFF
--- a/lib/morpheus/cli/mixins/provisioning_helper.rb
+++ b/lib/morpheus/cli/mixins/provisioning_helper.rb
@@ -1067,7 +1067,7 @@ module Morpheus::Cli::ProvisioningHelper
 
     no_prompt = (options[:no_prompt] || (options[:options] && options[:options][:no_prompt]))
     volumes = []
-    plan_size = nil
+    plan_size = 0
     if plan_info['maxStorage'].to_i > 0
       plan_size = plan_info['maxStorage'].to_i / (1024 * 1024 * 1024)
     end


### PR DESCRIPTION
https://hpe.atlassian.net/browse/PCCM-127542

When attempting to add a bare metal instance using the CLI, the request payload sends "volumes.size": null 
The backend expects volumes. size to be of type int, resulting in a DB exception.
( Note: testing only with Root volume) 

<img width="1715" height="509" alt="image" src="https://github.com/user-attachments/assets/7d96cfac-9b06-4c4f-8bd1-39f35d37b671" />


**CURL payload sent by CLI**
```
Add an environment variable? (yes/no) [no]:
Add a metadata tag? (yes/no) [no]: 

CURL COMMAND (
curl -XPOST "http://10.152.2.44:8080/api/instances" \
  -H "Authorization: Bearer 9563a144-6fa9-453b-85c2-dc1326bd1967" \
  -H "Content-Type: application/json" \
  -d '{
  "instance": {
    "name": "sdf",
    "cloud": "hpecloud",
    ......
    "volumes": [
    {
      "id": -1,
      "rootVolume": true,
      "name": "root",
      "size": null,
      "sizeId": null,
      "storageType": 79,
      "datastoreId": null
    }
  ],
     .......
 }'

```

**Service Plan Used:**
 https://github.com/HPE-EMU/hpe-baremetal-plugin/blob/e3a91641c03ba4111c64e6524257a4829304115c/src/main/groovy/com/hpe/ilo/provisioning/HpeBaremetalPluginProvisionProvider.groovy#L729

**Root Volume Type Used: **
https://github.com/HPE-EMU/hpe-baremetal-plugin/blob/e3a91641c03ba4111c64e6524257a4829304115c/src/main/groovy/com/hpe/ilo/provisioning/HpeBaremetalPluginProvisionProvider.groovy#L630