### PR TITLE
fix hosts.rb to be aware of iLO BareMetal to control prompting of service plan and networks.

### DIFF
--- a/lib/morpheus/cli/commands/hosts.rb
+++ b/lib/morpheus/cli/commands/hosts.rb
@@ -839,8 +839,6 @@ class Morpheus::Cli::Hosts
           exit 1
         end
 
-        print_red_alert "Server Type #{server_type_code} for cloud #{cloud['name']}: #{server_type['computeTypeCode']}"
-
         # Server Name
         host_name = nil
         if options[:host_name]


### PR DESCRIPTION
HPE BareMetal server import should not prompt for service plan or networks.  To achieve this, this change adds logic to hosts.rb to check for server_type_code == IloBareMetalHost; server_type.bareMetalHost == true may apply more than iLO bareMetal.

This PR is dependent on https://github.com/HPE-EMU/hpe-baremetal-plugin/pull/260, which changes the iLO BareMetal ComputeServerType code to 'IloBareMetalHost'