### PR TITLE
[MORPH-8428] Add `systems validate` subcommand

### DIFF
--- a/lib/morpheus/api/systems_interface.rb
+++ b/lib/morpheus/api/systems_interface.rb
@@ -15,4 +15,9 @@ class Morpheus::SystemsInterface < Morpheus::RestInterface
     execute(method: :put, url: "#{base_path}/#{CGI::escape(id.to_s)}/initialize", params: params, payload: payload, headers: headers)
   end
 
+  def validate_system(id, params={}, headers={})
+    validate_id!(id)
+    execute(method: :get, url: "#{base_path}/#{CGI::escape(id.to_s)}/validate", params: params, headers: headers)
+  end
+
 end

--- a/lib/morpheus/cli/commands/systems.rb
+++ b/lib/morpheus/cli/commands/systems.rb
@@ -6,7 +6,7 @@ class Morpheus::Cli::Systems
 
   set_command_name :systems
   set_command_description "View and manage systems."
-  register_subcommands :list, :get, :add, :update, :remove, :'add-uninitialized', {:'initialize' => 'exec_initialize'}
+  register_subcommands :list, :get, :add, :update, :remove, :'add-uninitialized', {:'initialize' => 'exec_initialize'}, {:'validate' => 'exec_validate'}
 
   protected
 
@@ -405,6 +405,47 @@ EOT
     render_response(json_response, options, rest_object_key) do
       print_green_success "System #{system['name']} initialized"
       get([system['id'].to_s] + (options[:remote] ? ['-r', options[:remote]] : []))
+    end
+  end
+
+  def exec_validate(args)
+    options = {}
+    params = {}
+    optparse = Morpheus::Cli::OptionParser.new do |opts|
+      opts.banner = subcommand_usage("[system]")
+      build_standard_get_options(opts, options)
+      opts.footer = <<-EOT
+Validate an existing system by running the provider's pre-check phase.
+No state changes are made. Returns success if the provider's prepare check passes.
+[system] is required. This is the name or id of a system.
+EOT
+    end
+    optparse.parse!(args)
+    verify_args!(args: args, optparse: optparse, count: 1)
+    connect(options)
+
+    system = nil
+    if args[0].to_s =~ /\A\d{1,}\Z/
+      json_response = rest_interface.get(args[0].to_i)
+      system = json_response[rest_object_key] || json_response
+    else
+      system = find_by_name(rest_key, args[0])
+    end
+    return 1, "System not found for '#{args[0]}'" if system.nil?
+
+    if options[:dry_run]
+      print_dry_run rest_interface.dry.validate_system(system['id'])
+      return
+    end
+
+    rest_interface.setopts(options)
+    json_response = rest_interface.validate_system(system['id'])
+    render_response(json_response, options) do
+      if json_response['success']
+        print_green_success "System #{system['name']} validated successfully"
+      else
+        print_red_alert "System #{system['name']} validation failed: #{json_response['msg']}"
+      end
     end
   end
 


### PR DESCRIPTION
Adds CLI support for the new GET /api/infrastructure/systems/{id}/validate endpoint introduced in MORPH-8428.