### PR TITLE
[MORPH-8427] update systems CLI for authoritative components

### DIFF
--- a/lib/morpheus/cli/commands/systems.rb
+++ b/lib/morpheus/cli/commands/systems.rb
@@ -27,6 +27,11 @@ class Morpheus::Cli::Systems
     'systems'
   end
 
+  # Required so find_by_name_or_id(:servers, id) resolves the lowercase 'server' key
+  def server_object_key
+    'server'
+  end
+
   def system_list_column_definitions(options)
     {
       "ID" => 'id',
@@ -60,6 +65,20 @@ class Morpheus::Cli::Systems
       print cyan
       print_description_list(rest_column_definitions(options), record, options)
       print reset,"\n"
+      components = record['components'] || []
+      if components.any?
+      	print_h2 "Components (#{components.size})", options
+      	component_rows = components.collect do |component|
+      		{
+      			id: component['id'],
+      			name: component['name'],
+      			type_code: component.dig('type', 'code'),
+      			type_name: component.dig('type', 'name'),
+      			external_id: component['externalId']
+      		}
+      	end
+      	print as_pretty_table(component_rows, [:id, :name, :type_code, :type_name, :external_id], options)
+      end
     end
   end
 
@@ -543,17 +562,38 @@ EOT
   def update(args)
     options = {}
     params = {}
+    components = []
+    components_specified = false
     optparse = Morpheus::Cli::OptionParser.new do |opts|
-      opts.banner = subcommand_usage("[system] --name --description")
+      opts.banner = subcommand_usage("[system]")
       opts.on("--name NAME", String, "Updates System Name") do |val|
         params['name'] = val.to_s
       end
       opts.on("--description [TEXT]", String, "Updates System Description") do |val|
         params['description'] = val.to_s
       end
+      opts.on('--enabled [on|off]', String, "Set whether the system is enabled") do |val|
+        params['enabled'] = val.to_s
+      end
+      opts.on('--externalId ID', String, "Set the external ID") do |val|
+        params['externalId'] = val.to_s
+      end
+      opts.on('--config JSON', String, "Set config JSON") do |val|
+        params['config'] = JSON.parse(val)
+      end
+      opts.on('--component JSON', String, "Component JSON (can be repeated). Pass the full desired component set when using component updates.") do |val|
+        components_specified = true
+        components << JSON.parse(val)
+      end
+      opts.on('--components JSON', String, "Components JSON array. This should be the full desired final component list.") do |val|
+        components_specified = true
+        components.concat(JSON.parse(val))
+      end
       build_standard_update_options(opts, options, [:find_by_name])
       opts.footer = <<-EOT
 Update an existing system.
+If system.components is supplied, it is authoritative: omitted components will be removed.
+Omit the components key entirely to leave components unchanged.
 [system] is required. This is the name or id of a system.
 EOT
     end
@@ -575,6 +615,9 @@ EOT
     params.booleanize!
 
     payload = parse_payload(options) || {rest_object_key => params}
+    payload[rest_object_key] ||= {}
+    payload[rest_object_key].deep_merge!(params) unless params.empty?
+    payload[rest_object_key]['components'] = components if components_specified
     if payload[rest_object_key].nil? || payload[rest_object_key].empty?
       raise_command_error "Specify at least one option to update.\n#{optparse}"
     end

--- a/test/cli/systems_test.rb
+++ b/test/cli/systems_test.rb
@@ -66,4 +66,97 @@ class SystemsCommandTest < Test::Unit::TestCase
     assert_equal '3', captured_request[:update_definition_id]
   end
 
+  def test_update_dry_run_with_components_payload
+    command = Morpheus::Cli::Systems.new
+    captured_request = nil
+    interface = Object.new
+    interface.define_singleton_method(:get) do |id|
+      {'system' => {'id' => id, 'name' => "system-#{id}"}}
+    end
+    interface.define_singleton_method(:dry) { self }
+    interface.define_singleton_method(:update) do |id, payload|
+      {method: :put, id: id, payload: payload}
+    end
+    command.define_singleton_method(:connect) do |options|
+    end
+    command.define_singleton_method(:rest_interface) do
+      interface
+    end
+    command.define_singleton_method(:print_dry_run) do |request|
+      captured_request = request
+    end
+
+    result = command.send(:update, ['--dry-run', '1', '--description', 'updated', '--component', '{"id":17,"name":"CN-CLI-1"}', '--component', '{"typeCode":"dummy-storage-controller","name":"SC-CLI-1"}'])
+
+    assert_nil result
+    assert_equal :put, captured_request[:method]
+    assert_equal 1, captured_request[:id]
+    assert_equal 'updated', captured_request[:payload]['system']['description']
+    assert_equal 2, captured_request[:payload]['system']['components'].size
+    assert_equal 17, captured_request[:payload]['system']['components'][0]['id']
+    assert_equal 'dummy-storage-controller', captured_request[:payload]['system']['components'][1]['typeCode']
+  end
+
+  def test_update_dry_run_allows_empty_components_array
+    command = Morpheus::Cli::Systems.new
+    captured_request = nil
+    interface = Object.new
+    interface.define_singleton_method(:get) do |id|
+      {'system' => {'id' => id, 'name' => "system-#{id}"}}
+    end
+    interface.define_singleton_method(:dry) { self }
+    interface.define_singleton_method(:update) do |id, payload|
+      {method: :put, id: id, payload: payload}
+    end
+    command.define_singleton_method(:connect) do |options|
+    end
+    command.define_singleton_method(:rest_interface) do
+      interface
+    end
+    command.define_singleton_method(:print_dry_run) do |request|
+      captured_request = request
+    end
+
+    result = command.send(:update, ['--dry-run', '1', '--components', '[]'])
+
+    assert_nil result
+    assert_equal :put, captured_request[:method]
+    assert_equal [], captured_request[:payload]['system']['components']
+  end
+
+  def test_render_response_for_get_includes_components_table
+    command = Morpheus::Cli::Systems.new
+    captured_rows = nil
+    command.define_singleton_method(:render_response) do |json_response, options, key, &block|
+      block.call if block
+    end
+    command.define_singleton_method(:print_h1) do |*args|
+    end
+    command.define_singleton_method(:print_h2) do |*args|
+    end
+    command.define_singleton_method(:print_description_list) do |*args|
+    end
+    command.define_singleton_method(:print) do |*args|
+    end
+    command.define_singleton_method(:as_pretty_table) do |rows, columns, options|
+      captured_rows = rows
+      "TABLE"
+    end
+
+    command.send(:render_response_for_get, {
+      'system' => {
+        'id' => 1,
+        'name' => 'system-1',
+        'components' => [
+          {'id' => 17, 'name' => 'CN-CLI-1', 'externalId' => 'ext-17', 'type' => {'code' => 'dummy-compute-node', 'name' => 'Compute Node'}}
+        ]
+      }
+    }, {})
+
+    assert_equal 1, captured_rows.size
+    assert_equal 17, captured_rows[0][:id]
+    assert_equal 'dummy-compute-node', captured_rows[0][:type_code]
+    assert_equal 'ext-17', captured_rows[0][:external_id]
+  end
+
 end


### PR DESCRIPTION
Updates to the systems cli commands that allows a user to update a system and using a component payload, to remove/add components. includes some updated tests as well. 