### PR TITLE
MORPH-12454: Add --include-tenants and --tenant filters to storage-volumes list

### DIFF
--- a/lib/morpheus/cli/commands/storage_volumes.rb
+++ b/lib/morpheus/cli/commands/storage_volumes.rb
@@ -29,12 +29,28 @@ class Morpheus::Cli::StorageVolumes
     opts.on('--category VALUE', String, "Filter by category") do |val|
       params['category'] = val
     end
+    opts.on('--include-tenants', '--include-tenants', "Include sub-tenant storage volumes (master tenant only)") do
+      options[:include_tenants] = true
+      params['includeTenants'] = true
+    end
+    opts.on('--tenant TENANT', String, "Filter by Tenant Name or ID (master tenant only)") do |val|
+      options[:tenant] = val
+    end
     # build_standard_list_options(opts, options)
     super
   end
 
   def parse_list_options!(args, options, params)
     parse_parameter_as_resource_id!(:storage_server, options, params)
+    if options[:tenant]
+      if options[:tenant].to_s =~ /\A\d+\Z/
+        params['tenantId'] = options[:tenant]
+      else
+        account = find_account_by_name_or_id(options[:tenant])
+        return 1 if account.nil?
+        params['tenantId'] = account['id']
+      end
+    end
     super
   end
 

--- a/test/cli/storage_volumes_test.rb
+++ b/test/cli/storage_volumes_test.rb
@@ -1,0 +1,79 @@
+require 'morpheus_test'
+
+# Tests for Morpheus::Cli::StorageVolumes
+class MorpheusTest::StorageVolumesTest < MorpheusTest::TestCase
+
+  def test_storage_volumes_list
+    assert_execute %(storage-volumes list)
+  end
+
+  def test_storage_volumes_get
+    storage_volume = client.storage_volumes.list({})['storageVolumes'][0]
+    if storage_volume
+      assert_execute %(storage-volumes get "#{storage_volume['id']}")
+    else
+      puts "No storage volumes found, unable to execute test `#{__method__}`"
+    end
+  end
+
+  # CLI-side validation: --tenant is required (no network call needed).
+  def test_storage_volumes_update_tenant_requires_tenant
+    assert_error %(storage-volumes update-tenant 1), "Expected missing --tenant to fail with a usage error"
+  end
+
+  # Happy path is verified with --dry-run so the test never mutates real ownership.
+  # Confirms the volume is resolved and the PUT payload is built as expected.
+  def test_storage_volumes_update_tenant_dry_run
+    storage_volume = client.storage_volumes.list({})['storageVolumes'].find {|it| it['status'] == 'unattached' }
+    storage_volume ||= client.storage_volumes.list({})['storageVolumes'][0]
+    if storage_volume
+      tenant = client.accounts.list({})['accounts'][0]
+      if tenant
+        assert_execute %(storage-volumes update-tenant "#{storage_volume['id']}" --tenant "#{tenant['id']}" --dry-run)
+      else
+        puts "No tenants found, unable to execute test `#{__method__}`"
+      end
+    else
+      puts "No storage volumes found, unable to execute test `#{__method__}`"
+    end
+  end
+
+  # --include-tenants adds includeTenants=true to the list request (master tenant only).
+  def test_storage_volumes_list_include_tenants_dry_run
+    assert_execute %(storage-volumes list --include-tenants --dry-run)
+    output = capture_terminal_stdout { terminal.execute %(storage-volumes list --include-tenants --dry-run) }
+    assert_match(/includeTenants=true/, output, "Expected includeTenants=true in the dry-run request")
+  end
+
+  # --tenant with a numeric id resolves directly to tenantId without an account lookup.
+  def test_storage_volumes_list_tenant_id_dry_run
+    assert_execute %(storage-volumes list --tenant 1 --dry-run)
+    output = capture_terminal_stdout { terminal.execute %(storage-volumes list --tenant 1 --dry-run) }
+    assert_match(/tenantId=1/, output, "Expected tenantId=1 in the dry-run request")
+  end
+
+  # --tenant with a name resolves to an id via the accounts API, then sets tenantId.
+  def test_storage_volumes_list_tenant_name_dry_run
+    tenant = client.accounts.list({})['accounts'][0]
+    if tenant
+      output = capture_terminal_stdout { terminal.execute %(storage-volumes list --tenant "#{tenant['name']}" --dry-run) }
+      assert_match(/tenantId=#{tenant['id']}/, output, "Expected tenantId=#{tenant['id']} resolved from tenant name")
+    else
+      puts "No tenants found, unable to execute test `#{__method__}`"
+    end
+  end
+
+  private
+
+  # Capture everything written to the terminal's stdout while the block runs.
+  def capture_terminal_stdout
+    original_stdout = terminal.stdout
+    buffer = StringIO.new
+    terminal.set_stdout(buffer)
+    yield
+    buffer.string
+  ensure
+    terminal.set_stdout(original_stdout)
+  end
+
+end


### PR DESCRIPTION
Adds tenant scoping to `storage-volumes list`, matching the pattern already used by `clouds list` and `hosts list`.