### PR TITLE
[MORPH-10751] CLI command parsing issue during virtual-image upload

### DIFF
--- a/lib/morpheus/api/virtual_images_interface.rb
+++ b/lib/morpheus/api/virtual_images_interface.rb
@@ -117,7 +117,11 @@ class Morpheus::VirtualImagesInterface < Morpheus::APIClient
          gz.close
       }
       http_opts[:body] = Morpheus::BodyIO.new(rd)
-      response = http.post(url, http_opts)
+      if Gem::Version.new(HTTP::VERSION) >= Gem::Version.new("6.0.0")
+        response = http.post(url, **http_opts)
+      else
+        response = http.post(url, http_opts)
+      end
     else
       if @dry_run
         return {method: :post, url: url, headers: headers, params: query_params, payload: payload}
@@ -126,7 +130,11 @@ class Morpheus::VirtualImagesInterface < Morpheus::APIClient
       http = HTTP.headers(headers)
       http_opts[:params] = query_params
       http_opts[:body] = payload
-      response = http.post(url, http_opts)
+      if Gem::Version.new(HTTP::VERSION) >= Gem::Version.new("6.0.0")
+        response = http.post(url, **http_opts)
+      else
+        response = http.post(url, http_opts)
+      end
     end
     # puts "Took #{Time.now.to_i - start_time.to_i}"
     # return response


### PR DESCRIPTION
 **Problem**
 `morpheus virtual-images add-file <image> <file>` failed with:
 
     ArgumentError: wrong number of arguments (given 2, expected 1)
     .../http/chainable/verbs.rb:47:in `post'
     .../api/virtual_images_interface.rb:129:in `upload'
 
 **Root cause**
 Virtual-image upload is the only place the CLI calls the http.rb gem
 directly. The gem's `#post` signature changed between major versions:
 
 | http version | `post` signature        | `post(url, hash)` |
 |--------------|-------------------------|-------------------|
 | 5.x          | `post(uri, options={})` | works             |
 | 6.x          | `post(uri, **)`         | ArgumentError     |
 
 CLI 8.1.0 shipped with `http` unpinned, so installs resolved to 6.x and
 the positional-hash call broke. (The gemspec was later pinned to 5.3.1,
 but this hardens the code so a future http upgrade won't reintroduce the
 bug.)
 
 **Fix**
 Branch on `HTTP::VERSION` at both upload call sites (normal + gzip) to
 use the keyword form on 6.x and the positional form on 5.x.