### PR TITLE
--storage-controller option for instance/host add and resize

### DIFF
--- a/lib/morpheus/cli/commands/hosts.rb
+++ b/lib/morpheus/cli/commands/hosts.rb
@@ -796,6 +796,10 @@ class Morpheus::Cli::Hosts
       opts.on("--security-groups LIST", Integer, "Security Groups, comma separated list of security group IDs") do |val|
         options[:security_groups] = val.split(",").collect {|s| s.strip }.select {|s| !s.to_s.empty? }
       end
+      opts.on("--storage-controller ARRAY", String, "Storage Controllers, JSON array of controller configs. Each entry accepts id, busNumber, typeId, typeName, removable, editable.") do |val|
+        options[:options] ||= {}
+        options[:options]['storageController'] = JSON.parse(val)
+      end
       opts.on('--tags LIST', String, "Metadata tags in the format 'ping=pong,flash=bang'") do |val|
         options[:metadata] = val
       end
@@ -954,6 +958,10 @@ class Morpheus::Cli::Hosts
           volumes = prompt_volumes(service_plan, provision_type, options, @api_client, {zoneId: cloud_id, serverTypeId: server_type['id'], siteId: group_id})
           if !volumes.empty?
             payload['volumes'] = volumes
+          end
+
+          if options[:options] && options[:options]['storageController']
+            payload['storageController'] = options[:options]['storageController']
           end
 
           # plan customizations
@@ -1347,6 +1355,10 @@ class Morpheus::Cli::Hosts
     options = {}
     optparse = Morpheus::Cli::OptionParser.new do |opts|
       opts.banner = subcommand_usage("[name]")
+      opts.on("--storage-controller ARRAY", String, "Storage Controllers, JSON array of controller configs. Each entry accepts id, busNumber, typeId, typeName, removable, editable.") do |val|
+        options[:options] ||= {}
+        options[:options]['storageController'] = JSON.parse(val)
+      end
       build_common_options(opts, options, [:options, :json, :dry_run, :quiet, :remote])
     end
     optparse.parse!(args)
@@ -1435,6 +1447,9 @@ class Morpheus::Cli::Hosts
       # only amazon supports this option
       # for now, always do this
       payload[:deleteOriginalVolumes] = true
+      if options[:options] && options[:options]['storageController']
+        payload[:storageController] = options[:options]['storageController']
+      end
       @servers_interface.setopts(options)
       if options[:dry_run]
         print_dry_run @servers_interface.dry.resize(server['id'], payload)

--- a/lib/morpheus/cli/commands/instances.rb
+++ b/lib/morpheus/cli/commands/instances.rb
@@ -465,6 +465,10 @@ class Morpheus::Cli::Instances
       opts.on("--layout-size NUMBER", Integer, "Apply a multiply factor of containers/vms within the instance") do |val|
         options[:layout_size] = val.to_i
       end
+      opts.on("--storage-controller ARRAY", String, "Storage Controllers, JSON array of controller configs. Each entry accepts id, busNumber, typeId, typeName, removable, editable. Example: '[{\"busNumber\":\"1\",\"typeName\":\"SCSI\"}]'") do |val|
+        options[:options] ||= {}
+        options[:options]['storageController'] = JSON.parse(val)
+      end
       opts.on( '-l', '--layout LAYOUT', "Layout ID" ) do |val|
         options[:layout] = val
       end
@@ -595,6 +599,9 @@ class Morpheus::Cli::Instances
     end
     
     payload['instance'] ||= {}
+    if options[:options] && options[:options]['storageController']
+      payload['storageController'] = options[:options]['storageController']
+    end
     if options[:instance_name]
       payload['instance']['name'] = options[:instance_name]
     end
@@ -2909,6 +2916,10 @@ class Morpheus::Cli::Instances
       opts.banner = subcommand_usage("[instance]")
       opts.on('--include-network-interfaces','--include-network-interfaces', "Populate payload networkInterfaces with current interfaces") do
         options[:include_nics] = true
+      end
+      opts.on("--storage-controller ARRAY", String, "Storage Controllers, JSON array of controller configs. Each entry accepts id, busNumber, typeId, typeName, removable, editable.") do |val|
+        options[:options] ||= {}
+        options[:options]['storageController'] = JSON.parse(val)
       end
       build_standard_update_options(opts, options)
     end


### PR DESCRIPTION
Accept a JSON array via --storage-controller on `instances add`, `instances resize`, `hosts add` and `hosts resize`. Each entry supports id, busNumber, typeId, typeName, removable, editable and is forwarded to the API in the top-level storageController payload key. The API side then flips storageControllersEnabled so downstream provision/resize services actually create the requested controllers.